### PR TITLE
disable hospital pipeline

### DIFF
--- a/crontab.txt
+++ b/crontab.txt
@@ -32,7 +32,7 @@ MAILTO=ubuntu@covid19-utility-server
 10 7 * * 4 /home/ubuntu/Development/covid19-crons/run_cron.sh CovidStateDashboardTablesCasesDeaths 
 
 # 7:20a on Thursday
-20 7 * * 4 /home/ubuntu/Development/covid19-crons/run_cron.sh CovidStateDashboardTablesHospitals
+#20 7 * * 4 /home/ubuntu/Development/covid19-crons/run_cron.sh CovidStateDashboardTablesHospitals
 
 # 7:30a on Thursday
 30 7 * * 4 /home/ubuntu/Development/covid19-crons/run_cron.sh CovidStateDashboardTablesTests

--- a/daemons/dashboarddeltas/deltabot_config.py
+++ b/daemons/dashboarddeltas/deltabot_config.py
@@ -75,20 +75,20 @@ file_list = [
             # (0.00700, 0.21746,  -0.00941, 0.02998,   -0.21198, 0.27496),
             'flags':('always_changes')
         },
-        {   'desc':'Total Hospitalizations',
-            'field':'data.hospitalizations.HOSPITALIZED_COVID_CONFIRMED_PATIENTS',
-            'date_check': 'data.hospitalizations.DATE',
-            'expected_growth_range': (-0.048780, 0.114062),
-            # (915.0, 9279.0,  -306.0, 639.0,   -0.048780, 0.114062),
-            'flags':('always_changes')
-        },
-        {   'desc':'Total ICU',
-            'field':'data.icu.ICU_COVID_CONFIRMED_PATIENTS',
-            'date_check': 'data.icu.DATE',
-            'expected_growth_range': (-0.093923, 0.181070),
-            # (219.0, 2128.0,  -143.0, 192.0,   -0.093923, 0.181070),
-            'flags':('always_changes')
-        },
+        #{   'desc':'Total Hospitalizations',
+        #    'field':'data.hospitalizations.HOSPITALIZED_COVID_CONFIRMED_PATIENTS',
+        #    'date_check': 'data.hospitalizations.DATE',
+        #    'expected_growth_range': (-0.048780, 0.114062),
+        #    # (915.0, 9279.0,  -306.0, 639.0,   -0.048780, 0.114062),
+        #    'flags':('always_changes')
+        #},
+        #{   'desc':'Total ICU',
+        #    'field':'data.icu.ICU_COVID_CONFIRMED_PATIENTS',
+        #    'date_check': 'data.icu.DATE',
+        #    'expected_growth_range': (-0.093923, 0.181070),
+        #    # (219.0, 2128.0,  -143.0, 192.0,   -0.093923, 0.181070),
+        #    'flags':('always_changes')
+        #},
         # Hospitalization Changee and ICU change is sometimes zero which produces issues
     ]
   },


### PR DESCRIPTION
Due to the transition from CHA to NHSN data, there is no data this week. Disabling pipeline until a new one can be written. Hospital/ICU data is still queried in the dashboard summary job but that should be left in (despite not getting updates) due to the risk of breaking some downstream consumer of the summary data.